### PR TITLE
Fixed compiling issue for GCC-9

### DIFF
--- a/base/src/UtilityFunctions.cc
+++ b/base/src/UtilityFunctions.cc
@@ -356,10 +356,10 @@ namespace Force {
       try {
         amount = stoul(size_text);
       }
-      catch (invalid_argument) {
+      catch (invalid_argument&) {
         // Handled below by checking if amount is 0.
       }
-      catch (out_of_range) {
+      catch (out_of_range&) {
         // Handled below by checking if amount is 0.
       }
     }


### PR DESCRIPTION
The compiling issue raised by "Doesn't build on CentOS 7 nor Ubuntu 20.04 #7" is fixed.