### PR TITLE
Ensure "make" works out of the box as per the user guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+export FORCE_CC ?= g++
+PYVER != python3 --version | sed -n -e 's/Python \(3\.[[:digit:]]\+\)\..*/\1/p'
+export FORCE_PYTHON_VER ?= $(PYVER)
+
+# this really ought to use pkg-config - there could be more than one include
+# directory.
+export FORCE_PYTHON_INC ?= /usr/include/python$(FORCE_PYTHON_VER)
+export FORCE_PYTHON_LIB ?= /usr/lib/x86_64-linux-gnu/
+
 all:
 	@$(MAKE) riscv
 	@$(MAKE) fpix

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The user manual is located in the 'force-riscv/doc' directory.  The user manual 
 * Clone the FORCE-RISCV repository:
   * The \[base directory\] in the description that follows is the directory from which you execute git clone.
   * git clone http://path-to-the-repository/force-riscv.git
-* Set the following environment variables.  FORCE-RISCV development requires gcc 5.1 or higher and Python 3.4.1 or higher version.
+* Set the following environment variables.  FORCE-RISCV development requires gcc 5.1 or higher and Python 3.4.1 or higher version.  The Makefile will make a guess if you don't set them, which should be suitable for modern 64-bit GNU/Linux distributions.
   * export FORCE_CC=/usr/bin/g++
   * export FORCE_PYTHON_VER=3.6
   * export FORCE_PYTHON_LIB=/usr/lib/x86_64-linux-gnu/


### PR DESCRIPTION
	The user manual says you can just use "make" to build the system,
	but in fact you need to set several environment variables.  This
	patch attempts to put sensible defaults in place, which the user
	can chose to override.  These values should be suitable on modern
	64-bit Intel/AMD Linux distributions.

Files changed:

	* Makefile: Provide default values for FORCE_CC, FORCE_PYTHON_VER,
	PYTHON_INC and PYTHON_LIB.
	* README.md: Update to note that default values are set for
	FORCE_CC, FORCE_PYTHON_VER, PYTHON_INC and PYTHON_LIB.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>