### PR TITLE
Provide a more consistent output of the encoded instruction

### DIFF
--- a/base/src/TestIO.cc
+++ b/base/src/TestIO.cc
@@ -212,8 +212,14 @@ namespace Force {
       const ThreadInstructionResults* inst_results = generator->GetInstructionResults();
       const std::map<uint64, Instruction* >& instructions = inst_results->GetInstructions(memBank);
 
+      /*!
+	TODO: hex dump of instruction assumes 8 hex digits (32-bit
+	      instructions).  If the architecture permits variable length
+	      instructions, then the opcode length should be obtained form the
+	      architecture as part of the instruction information.
+      */
       for (auto inst : instructions)
-          asmFile << fmtx0(inst.first, 16) << ":" << fmtx0(inst.second->Opcode()) << " " << inst.second->AssemblyText() << endl;
+	  asmFile << fmtx0(inst.first, 16) << ":" << fmtx0(inst.second->Opcode(), 8) << " " << inst.second->AssemblyText() << endl;
     }
 #endif
     /*!


### PR DESCRIPTION
	The encoded instruction hex was being dumped to the assembly file
	in minimal length, making it hard to read when and encoding has
	leading zeros. This is a partial fix, which prints all decodes as
	32-bit width.

	However the architecture should be interrogated to ask what
	instruction length should be used, and the field padded as
	necessary with blanks. This will be needed for correct binary
	representation of architectures with variable length instructions,
	or fixed instruction length other than 32.

Files changed:

	* base/src/TestIO.cc (TestImage::DumpToAssembly): Force output of
	the opcode hex representation to be 8 hex digits long.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>