### PR TITLE
Fixed compilation error: std::string and int64_t undefined

### DIFF
--- a/fpix/inc/ParseGuide.h
+++ b/fpix/inc/ParseGuide.h
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 #include <map>
+#include <string>
+#include <cstdint>
 
 namespace Force
 {


### PR DESCRIPTION
Error message:

```
g++ -c -Wall -std=c++11 -gdwarf-3 -m64 -O2 -Weffc++  -D 'ARCH_ENUM_HEADER=<Enums.h>' -DUNIT_TEST -I./inc -I../inc -I../../base/inc -I../../3rd_party/inc -I../../utils/handcar -I/usr/include/python3.9 -o make_area/obj/ParseGuide.o ../src/ParseGuide.cc
In file included from ../src/ParseGuide.cc:16:
../inc/ParseGuide.h:23:14: error: ‘string’ in namespace ‘std’ does not name a type
   23 |         std::string _mName;
      |              ^~~~~~
../inc/ParseGuide.h:17:1: note: ‘std::string’ is defined in header ‘<string>’; did you forget to ‘#include <string>’?
   16 | #include <map>
  +++ |+#include <string>
   17 | 
../inc/ParseGuide.h:24:9: error: ‘int32_t’ does not name a type
   24 |         int32_t * _mpInt32;
      |         ^~~~~~~
../inc/ParseGuide.h:25:9: error: ‘int64_t’ does not name a type
   25 |         int64_t * _mpInt64;
      |         ^~~~~~~
../inc/ParseGuide.h:26:9: error: ‘uint32_t’ does not name a type
   26 |         uint32_t * _mpUint32;
      |         ^~~~~~~~
../inc/ParseGuide.h:27:9: error: ‘uint64_t’ does not name a type
   27 |         uint64_t * _mpUint64;
      |         ^~~~~~~~
../inc/ParseGuide.h:28:14: error: ‘string’ in namespace ‘std’ does not name a type
   28 |         std::string * _mpString;
```